### PR TITLE
Add healthchecks and align Keycloak production edge config.

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -53,10 +53,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U unicnet -d unicnetdb"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-unicnet} -d ${POSTGRES_DB:-unicnetdb}"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 10s
     deploy:
       resources:
         limits:
@@ -82,39 +83,35 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 30s
 
   unicnet.keycloak:
     container_name: unicnetkeycloak
     image: cr.yandex/crp39psc34hg49unp6p7/keycloak:22.0.5
     restart: unless-stopped
     environment:
-      KEYCLOAK_MODE: "production"
-      KEYCLOAK_DATABASE_TYPE: "postgresql"
-      KEYCLOAK_DATABASE_HOST: "unicnetpostgres"
-      KEYCLOAK_DATABASE_PORT_NUMBER: "5432"
-      KEYCLOAK_DATABASE_NAME: "${POSTGRES_DB:-unicnetdb}"
-      KEYCLOAK_DATABASE_USER: "${POSTGRES_USER:-unicnet}"
-      KEYCLOAK_DATABASE_PASSWORD: "${POSTGRES_PASSWORD:-postgres123}"
-      KEYCLOAK_ADMIN_USER: "${KEYCLOAK_ADMIN_USER:-unicnet}"
-      KEYCLOAK_ADMIN_PASSWORD: "${KEYCLOAK_ADMIN_PASSWORD:-admin123}"
-      KEYCLOAK_JDBC_PARAMS: "sslmode=disable&connectTimeout=60000"
+      KEYCLOAK_PRODUCTION: "true"
+      KEYCLOAK_PROXY: "edge"
+      KEYCLOAK_ENABLE_HTTPS: "false"
+      KEYCLOAK_HTTP_ENABLED: "true"
       KEYCLOAK_HOSTNAME_STRICT: "false"
       KEYCLOAK_HOSTNAME_STRICT_HTTPS: "false"
-      KEYCLOAK_HTTP_ENABLED: "true"
-      KEYCLOAK_PROXY: "edge"
       KEYCLOAK_ENABLE_HEALTH: "true"
       KEYCLOAK_ENABLE_METRICS: "true"
-      KC_DB: "postgres"
+      KEYCLOAK_DATABASE_HOST: unicnetpostgres
+      KEYCLOAK_DATABASE_PORT_NUMBER: "5432"
+      KEYCLOAK_DATABASE_NAME: ${POSTGRES_DB:-unicnetdb}
+      KEYCLOAK_DATABASE_USER: ${POSTGRES_USER:-unicnet}
+      KEYCLOAK_DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-postgres123}
+      KEYCLOAK_ADMIN_USER: ${KEYCLOAK_ADMIN_USER:-unicnet}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin123}
+      KEYCLOAK_JDBC_PARAMS: "sslmode=disable&connectTimeout=60000"
+      KC_DB: postgres
       KC_DB_URL: "jdbc:postgresql://unicnetpostgres:5432/${POSTGRES_DB:-unicnetdb}"
-      KC_DB_USERNAME: "${POSTGRES_USER:-unicnet}"
-      KC_DB_PASSWORD: "${POSTGRES_PASSWORD:-postgres123}"
-      KC_DB_URL_PROPERTIES: "sslmode=disable&connectTimeout=60000"
+      KC_DB_USERNAME: ${POSTGRES_USER:-unicnet}
+      KC_DB_PASSWORD: ${POSTGRES_PASSWORD:-postgres123}
       KC_HTTP_ENABLED: "true"
-      KC_PROXY: "edge"
       KC_HOSTNAME_STRICT: "false"
-      KC_HOSTNAME_STRICT_HTTPS: "false"
-      KEYCLOAK_PRODUCTION: "true"
-      KC_PROFILE: "production"
     volumes:
       - ./keycloak-import:/opt/keycloak/data/import
     networks:
@@ -123,8 +120,15 @@ services:
       - "8095:8080"
       - "8096:8443"
       - "9990:9990"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/realms/master || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
     depends_on:
-      - unicnet.postgres
+      unicnet.postgres:
+        condition: service_healthy
 
   unicnet.backend:
     container_name: unicnetbackend
@@ -135,15 +139,27 @@ services:
       - api.logger.url=http://unicnetlogger:8080/
       - MongoCS=mongodb://${MONGO_UNICNET_USER:-unicnet}:${MONGO_UNICNET_PASSWORD:-unicnet_pass_123}@unicnetmongo:27017/${MONGO_UNICNET_DB:-unicnet_db}?directConnection=true&authSource=${MONGO_UNICNET_DB:-unicnet_db}&authMechanism=SCRAM-SHA-256
       - UniCommLicenseData=${UniCommLicenseData:-default_license_data}
-     
     networks:
       unicnet_network:
     ports:
       - "30111:8080"
+    volumes:
+      - ./scripts/check-port.sh:/check-port.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "/check-port.sh 8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     depends_on:
-      - unicnet.vault
-      - unicnet.router
-      - unicnet.syslog
+      unicnet.vault:
+        condition: service_healthy
+      unicnet.router:
+        condition: service_healthy
+      unicnet.syslog:
+        condition: service_healthy
+      unicnet.keycloak:
+        condition: service_healthy
 
   unicnet.frontend:
     container_name: unicnetfrontend
@@ -152,15 +168,24 @@ services:
     environment:
       - api.vault.url=http://unicnetvault:80/
       - UniCommLicenseData=${UniCommLicenseData:-default_license_data}
-     
     networks:
       unicnet_network:
     ports:
       - "8080:8080"
       - "8081:8081"
+    volumes:
+      - ./scripts/check-port.sh:/check-port.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "/check-port.sh 8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     depends_on:
-      - unicnet.backend
-      - unicnet.keycloak
+      unicnet.backend:
+        condition: service_healthy
+      unicnet.keycloak:
+        condition: service_healthy
 
   unicnet.logger:
     container_name: unicnetlogger
@@ -173,12 +198,25 @@ services:
     environment:
       - MongoCS=mongodb://${MONGO_LOGGER_USER:-logger_user}:${MONGO_LOGGER_PASSWORD:-logger_pass_123}@unicnetmongo:27017/${MONGO_LOGGER_DB:-logger_db}?directConnection=true&authSource=${MONGO_LOGGER_DB:-logger_db}&authMechanism=SCRAM-SHA-256
       - UniCommLicenseData=${UniCommLicenseData:-default_license_data}
+    volumes:
+      - ./scripts/check-port.sh:/check-port.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "/check-port.sh 8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
     depends_on:
-      - unicnet.mongo
-      - unicnet.vault
-      - unicnet.syslog
-      - unicnet.backend
-      - unicnet.frontend
+      unicnet.mongo:
+        condition: service_healthy
+      unicnet.vault:
+        condition: service_healthy
+      unicnet.syslog:
+        condition: service_healthy
+      unicnet.backend:
+        condition: service_healthy
+      unicnet.frontend:
+        condition: service_healthy
     deploy:
       resources:
         limits:
@@ -194,6 +232,7 @@ services:
       - "8200:80"
     volumes:
       - vault-data:/vault/file/
+      - ./scripts/check-port.sh:/check-port.sh:ro
     environment:
       - MongoCS=mongodb://${MONGO_VAULT_USER:-vault_user}:${MONGO_VAULT_PASSWORD:-vault_pass_123}@unicnetmongo:27017/${MONGO_VAULT_DB:-vault_db}?directConnection=true&authSource=${MONGO_VAULT_DB:-vault_db}&authMechanism=SCRAM-SHA-256
       - api.logger.url=http://unicnetlogger:8080/
@@ -204,8 +243,15 @@ services:
     command: server
     networks:
       - unicnet_network
+    healthcheck:
+      test: ["CMD-SHELL", "/check-port.sh 80"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
     depends_on:
-      - unicnet.mongo
+      unicnet.mongo:
+        condition: service_healthy
     deploy:
       resources:
         limits:
@@ -230,9 +276,19 @@ services:
       - UniCommLicenseData=${UniCommLicenseData:-default_license_data}
     cap_add:
       - NET_BIND_SERVICE
+    volumes:
+      - ./scripts/check-port.sh:/check-port.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "/check-port.sh 8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     depends_on:
-      - unicnet.mongo
-      - unicnet.vault
+      unicnet.mongo:
+        condition: service_healthy
+      unicnet.vault:
+        condition: service_healthy
     deploy:
       resources:
         limits:
@@ -253,6 +309,14 @@ services:
       # RouterCidr: как узнать на сервере — ip addr или ip route
       - RouterCidr=${RouterCidr:-}
       - UniCommLicenseData=${UniCommLicenseData:-default_license_data}
+    volumes:
+      - ./scripts/check-process.sh:/check-process.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "/check-process.sh UnicNet.Router"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     deploy:
       resources:
         limits:

--- a/app/scripts/check-port.sh
+++ b/app/scripts/check-port.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+PORT="${1:?port required}"
+
+if command -v nc >/dev/null 2>&1; then
+  nc -z localhost "$PORT"
+  exit $?
+fi
+
+if (echo >"/dev/tcp/127.0.0.1/$PORT") >/dev/null 2>&1; then
+  exit 0
+fi
+
+exit 1

--- a/app/scripts/check-process.sh
+++ b/app/scripts/check-process.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+PROCESS_NAME="${1:?process name required}"
+
+if command -v pgrep >/dev/null 2>&1; then
+  pgrep -f "$PROCESS_NAME" >/dev/null
+  exit $?
+fi
+
+if ps aux 2>/dev/null | grep -v grep | grep -q "$PROCESS_NAME"; then
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
Introduce port/process healthcheck scripts and service_healthy dependencies so services start in order on dev-like environments. Configure Keycloak for production with proxy=edge and HTTPS disabled in the container.